### PR TITLE
Fix status to reflect unofficial-ness

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,7 @@ Title: Document Policy
 Shortname: document-policy
 Level: 1
 Indent: 2
-Status: ED
+Status: CG-DRAFT
 Group: WICG
 URL: https://wicg.github.io/document-policy/
 Editor: Ian Clelland, Google, iclelland@google.com


### PR DESCRIPTION
This is a draft report in WICG, not an W3C editor's draft; I imagine the error here was a copypasta.