### PR TITLE
Fix recursive "document-policy" definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -196,7 +196,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     which is a <a>document policy</a>.
 
     A <a>Document</a> has a <dfn for="Document">document policy</dfn>, which is a
-    <a>document policy</a>.
+    <a for="/">document policy</a>.
 
     A <a>Document</a> has a <dfn>report-only document policy</dfn>, which is a
     <a>document policy</a>.


### PR DESCRIPTION
The previous link in "A document contains a document polocy, which is a
document policy" linked back to itself, rather than to the document
policy concept.

Closes: #41